### PR TITLE
Update README.md in polymer_using_emc_example

### DIFF
--- a/matlantis_contrib_examples/build_polymer_using_EMC_example/README.md
+++ b/matlantis_contrib_examples/build_polymer_using_EMC_example/README.md
@@ -21,11 +21,11 @@ Please download and setup the package.
   website: https://montecarlo.sourceforge.net/emc/Download.html  
   package: Linux x86_64 (Intel Architecture)  
 
-3. Put the tgz file in EMC_interface/EMC/.
+2. Put the tgz file in EMC_interface/EMC/.
 
-4. Run all cells in extract_EMC.ipynb.
+3. Run all cells in extract_EMC.ipynb.
 
-5. Execute example notebook(s).
+4. Execute example notebook(s).
 
 Please see 'v9.4.4/docs/emc.pdf' for more information. 
 


### PR DESCRIPTION
The download link on SourceForge was deleted because the linked package has expired.
Both the official website's download page and the package name were provided, instead.