### PR TITLE
chore: fix copyright notice

### DIFF
--- a/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_en.ipynb
+++ b/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_en.ipynb
@@ -19,7 +19,7 @@
     "tags": []
    },
    "source": [
-    "Copyright Preferred Computational Chemistry as contributors to Matlantis contrib project\n",
+    "Copyright 2024 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# Simulations of epoxy resin (Bisphenol-A dimer diglycidyl ether) pyrolysis\n",
     "- Thermal decomposition of epoxy resin is crucial in the design of plastic recycling processes. Typically, polymer molecules decompose into various small molecules at high temperatures. Such reaction processes can be simulated using classical molecular dynamics (MD) with a reactive force field (ReaxFF), which allows detailed analysis of decomposition reactions. However, fitting the force field parameters of ReaxFF is difficult. To address this, we have performed calculations using PFP, a pre-trained universal potential, and compared the results with ReaxFF (the PFP version and molecular structure have been changed from the example on the PFCC website.).  \n",

--- a/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_en.ipynb
+++ b/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_en.ipynb
@@ -19,7 +19,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2024 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2024 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# Simulations of epoxy resin (Bisphenol-A dimer diglycidyl ether) pyrolysis\n",
     "- Thermal decomposition of epoxy resin is crucial in the design of plastic recycling processes. Typically, polymer molecules decompose into various small molecules at high temperatures. Such reaction processes can be simulated using classical molecular dynamics (MD) with a reactive force field (ReaxFF), which allows detailed analysis of decomposition reactions. However, fitting the force field parameters of ReaxFF is difficult. To address this, we have performed calculations using PFP, a pre-trained universal potential, and compared the results with ReaxFF (the PFP version and molecular structure have been changed from the example on the PFCC website.).  \n",

--- a/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_en.ipynb
+++ b/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_en.ipynb
@@ -19,7 +19,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2024 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2024 Matlantis Corp. (formerly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# Simulations of epoxy resin (Bisphenol-A dimer diglycidyl ether) pyrolysis\n",
     "- Thermal decomposition of epoxy resin is crucial in the design of plastic recycling processes. Typically, polymer molecules decompose into various small molecules at high temperatures. Such reaction processes can be simulated using classical molecular dynamics (MD) with a reactive force field (ReaxFF), which allows detailed analysis of decomposition reactions. However, fitting the force field parameters of ReaxFF is difficult. To address this, we have performed calculations using PFP, a pre-trained universal potential, and compared the results with ReaxFF (the PFP version and molecular structure have been changed from the example on the PFCC website.).  \n",

--- a/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_ja.ipynb
+++ b/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_ja.ipynb
@@ -19,7 +19,7 @@
     "tags": []
    },
    "source": [
-    "Copyright Preferred Computational Chemistry as contributors to Matlantis contrib project\n",
+    "Copyright 2024 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "# エポキシ樹脂（Bisphenol-A dimer diglycidyl ether）の熱分解シミュレーション\n",
     "- エポキシ樹脂の熱分解反応は、プラスチックリサイクルのプロセス設計において重要です。通常、ポリマー分子の熱分解は高温で進行し、様々な小分子が生成されます。このような反応過程を扱う方法として、反応力場（ReaxFF）を用いた古典分子動力学（MD）シミュレーションが広く用いられています。これにより、分解反応を詳細に解析することが可能です。一方、ReaxFFは力場の作成が難しいという課題があります。そこで、学習済みの汎用ポテンシャルであるPFPを用いて同様の計算を行い、結果の検証を行いました（HPに公開済の事例から、PFPのバージョンと分子構造が変更されています）。  \n",
     "https://matlantis.com/calculation/thermal-decomposition-of-epoxy-molecules  \n",

--- a/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_ja.ipynb
+++ b/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_ja.ipynb
@@ -19,7 +19,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2024 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2024 Matlantis Corp. (formerly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "# エポキシ樹脂（Bisphenol-A dimer diglycidyl ether）の熱分解シミュレーション\n",
     "- エポキシ樹脂の熱分解反応は、プラスチックリサイクルのプロセス設計において重要です。通常、ポリマー分子の熱分解は高温で進行し、様々な小分子が生成されます。このような反応過程を扱う方法として、反応力場（ReaxFF）を用いた古典分子動力学（MD）シミュレーションが広く用いられています。これにより、分解反応を詳細に解析することが可能です。一方、ReaxFFは力場の作成が難しいという課題があります。そこで、学習済みの汎用ポテンシャルであるPFPを用いて同様の計算を行い、結果の検証を行いました（HPに公開済の事例から、PFPのバージョンと分子構造が変更されています）。  \n",
     "https://matlantis.com/calculation/thermal-decomposition-of-epoxy-molecules  \n",

--- a/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_ja.ipynb
+++ b/matlantis_contrib_examples/epoxy_pyrolysis/epoxy_pyrolysis_ja.ipynb
@@ -19,7 +19,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2024 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2024 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "# エポキシ樹脂（Bisphenol-A dimer diglycidyl ether）の熱分解シミュレーション\n",
     "- エポキシ樹脂の熱分解反応は、プラスチックリサイクルのプロセス設計において重要です。通常、ポリマー分子の熱分解は高温で進行し、様々な小分子が生成されます。このような反応過程を扱う方法として、反応力場（ReaxFF）を用いた古典分子動力学（MD）シミュレーションが広く用いられています。これにより、分解反応を詳細に解析することが可能です。一方、ReaxFFは力場の作成が難しいという課題があります。そこで、学習済みの汎用ポテンシャルであるPFPを用いて同様の計算を行い、結果の検証を行いました（HPに公開済の事例から、PFPのバージョンと分子構造が変更されています）。  \n",
     "https://matlantis.com/calculation/thermal-decomposition-of-epoxy-molecules  \n",

--- a/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_en.ipynb
+++ b/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_en.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Copyright 2022 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2022 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# H2O adsorption and diffusion in MOF-74Ni"
    ]

--- a/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_en.ipynb
+++ b/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_en.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Copyright 2022 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2022 Matlantis Corp. (formerly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# H2O adsorption and diffusion in MOF-74Ni"
    ]

--- a/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_en.ipynb
+++ b/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_en.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Copyright 2022 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "\n",
     "# H2O adsorption and diffusion in MOF-74Ni"
    ]
   },

--- a/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_ja.ipynb
+++ b/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_ja.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Copyright 2022 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2022 Matlantis Corp. (formerly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# MOF-74NiでのH2O分子の吸着と拡散"
    ]

--- a/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_ja.ipynb
+++ b/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_ja.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Copyright 2022 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "\n",
     "# MOF-74NiでのH2O分子の吸着と拡散"
    ]
   },

--- a/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_ja.ipynb
+++ b/matlantis_contrib_examples/mof-74Ni_h2o_adsorption_and_md/MOF-74_Ni_H2O_adsorption_wD3_ja.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Copyright 2022 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2022 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# MOF-74NiでのH2O分子の吸着と拡散"
    ]

--- a/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_en.ipynb
+++ b/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_en.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2023 Matlantis Corporation and Preferred Networks, Inc. as contributors to Matlantis contrib project\n",
+    "Copyright 2023 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
     "\n",
     "# Stress-Strain Curve for resin-metal slab model\n",
     "\n",

--- a/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_en.ipynb
+++ b/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_en.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2023 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
+    "Copyright 2023 Matlantis Corp. (formerly Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
     "\n",
     "# Stress-Strain Curve for resin-metal slab model\n",
     "\n",

--- a/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_en.ipynb
+++ b/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_en.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2023 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
+    "Copyright 2023 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
     "\n",
     "# Stress-Strain Curve for resin-metal slab model\n",
     "\n",

--- a/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_ja.ipynb
+++ b/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_ja.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2023 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
+    "Copyright 2023 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
     "\n",
     "# 樹脂-金属界面の応力-ひずみ曲線計算\n",
     "\n",

--- a/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_ja.ipynb
+++ b/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_ja.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2023 Matlantis Corp. (formally Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
+    "Copyright 2023 Matlantis Corp. (formerly Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
     "\n",
     "# 樹脂-金属界面の応力-ひずみ曲線計算\n",
     "\n",

--- a/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_ja.ipynb
+++ b/matlantis_contrib_examples/stress-strain_curve/stress_strain_curve_ja.ipynb
@@ -14,7 +14,8 @@
     "tags": []
    },
    "source": [
-    "Copyright 2023 Matlantis Corporation and Preferred Networks, Inc. as contributors to Matlantis contrib project\n",
+    "Copyright 2023 Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) and Preferred Networks Inc. as contributors to Matlantis contrib project\n",
+    "\n",
     "# 樹脂-金属界面の応力-ひずみ曲線計算\n",
     "\n",
     "本ノートブックでは、金属スラブに挟まれた樹脂の引っ張りシミュレーションを実行し、応力-ひずみ曲線を作成します。\n",

--- a/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_en.ipynb
+++ b/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_en.ipynb
@@ -6,7 +6,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "\n",
     "This document was machine translated from Japanese to English.\n",

--- a/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_en.ipynb
+++ b/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_en.ipynb
@@ -6,7 +6,8 @@
     "tags": []
    },
    "source": [
-    "Copyright ENEOS, Corp. and Preferred Computational Chemistry as contributors to Matlantis contrib project\n",
+    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "\n",
     "\n",
     "This document was machine translated from Japanese to English.\n",
     "\n",

--- a/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_en.ipynb
+++ b/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_en.ipynb
@@ -6,7 +6,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formerly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "\n",
     "This document was machine translated from Japanese to English.\n",

--- a/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_ja.ipynb
+++ b/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_ja.ipynb
@@ -6,7 +6,7 @@
     "tags": []
    },
    "source": [
-    "Copyright ENEOS, Corp. and Preferred Computational Chemistry as contributors to Matlantis contrib project\n",
+    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# Fe摺動面におけるリン酸のトライボケミカル反応\n",
     "\n",

--- a/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_ja.ipynb
+++ b/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_ja.ipynb
@@ -6,7 +6,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formerly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# Fe摺動面におけるリン酸のトライボケミカル反応\n",
     "\n",

--- a/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_ja.ipynb
+++ b/matlantis_contrib_examples/tribochem/TMP_tribochemical_matlantis_ja.ipynb
@@ -6,7 +6,7 @@
     "tags": []
    },
    "source": [
-    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formaly Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
+    "Copyright 2024 ENEOS Corp. and Matlantis Corp. (formally Preferred Computational Chemistry Inc.) as contributors to Matlantis contrib project\n",
     "\n",
     "# Fe摺動面におけるリン酸のトライボケミカル反応\n",
     "\n",


### PR DESCRIPTION
* Standardize company name notation to XXX Corp. (XXX Corporation, XXX, Corp., and XXX, Corp. should be corrected to XXX Corp.)
* Include publication year in copyright notice
  * [x] epoxy_pyrolysis_{ja,en}.ipynb; https://github.com/matlantis/matlantis-contrib/pull/57
  * [x] MOF-74_Ni_H2O_adsorption_wD3_{ja,en}.ipynb; https://github.com/matlantis/matlantis-contrib/pull/5
  * [x] stress_strain_curve_en.ipynb; already show publication year
  * [x] TMP_tribochemical_matlantis_{ja,en}.ipynb; https://github.com/matlantis/matlantis-contrib/pull/37
* Updated company name in copyright notices